### PR TITLE
Export the standard logrus entry variable

### DIFF
--- a/context/helpers.go
+++ b/context/helpers.go
@@ -11,7 +11,7 @@ import (
 func Background() Context {
 	return ctx{
 		Context: context.Background(),
-		Entry:   std,
+		Entry:   StdLogEntry,
 	}
 }
 
@@ -23,7 +23,7 @@ func WithCancel(parent Context) (Context, context.CancelFunc) {
 	if ctx, ok := parent.(*ctx); ok {
 		entry = ctx.Entry
 	} else {
-		entry = std
+		entry = StdLogEntry
 	}
 
 	ctx := ctx{
@@ -41,7 +41,7 @@ func WithDeadline(parent Context, deadline time.Time) (Context, context.CancelFu
 	if ctx, ok := parent.(*ctx); ok {
 		entry = ctx.Entry
 	} else {
-		entry = std
+		entry = StdLogEntry
 	}
 
 	ctx := &ctx{
@@ -59,7 +59,7 @@ func WithTimeout(parent Context, timeout time.Duration) (Context, context.Cancel
 	if ctx, ok := parent.(*ctx); ok {
 		entry = ctx.Entry
 	} else {
-		entry = std
+		entry = StdLogEntry
 	}
 
 	ctx := &ctx{
@@ -77,7 +77,7 @@ func WithValue(parent Context, key string, value interface{}) Context {
 	if ctx, ok := parent.(*ctx); ok {
 		entry = ctx.Entry
 	} else {
-		entry = std
+		entry = StdLogEntry
 	}
 
 	ctx := &ctx{

--- a/context/logger.go
+++ b/context/logger.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
-var std *logrus.Entry
+var StdLogEntry *logrus.Entry
 
 func init() {
 
@@ -29,7 +29,7 @@ func init() {
 	default:
 		l.Level = logrus.InfoLevel
 	}
-	std = logrus.NewEntry(l)
+	StdLogEntry = logrus.NewEntry(l)
 }
 
 type Logger interface {


### PR DESCRIPTION
The default log `Entry` pointer (called `std`, in package `github.com/omeid/gonzo/context`) is unexported. That's fine for most purposes, but when new `Context`s are created in the helper functions, they have an `Entry` value set to `std` – which means that it's not possible to make global configuration changes to the Logrus logger.

I humbly submit that `std` be exported (I've called it `StdLogEntry`, but the name doesn't really matter) so that new global Logrus configuration can be introduced. This change won't break any existing integrations or tests.
